### PR TITLE
Fix roll month format

### DIFF
--- a/src/components/roller/Roll.js
+++ b/src/components/roller/Roll.js
@@ -48,7 +48,7 @@ function RegularRoll({ roll }) {
           </Typography>
           <Typography textAlign="center">
             {roll.username} -{" "}
-            {format(roll.timestamp.toDate(), "dd/mm/yyyy hh:mm:ss")}
+            {format(roll.timestamp.toDate(), "dd/MM/yyyy hh:mm:ss")}
           </Typography>
         </Stack>
       </Stack>
@@ -235,7 +235,7 @@ function FabulaRoll({ roll, saveRoll, currentUser }) {
               <Typography textAlign="center" key={i} fontSize="0.9rem">
                 {roll.username} <Diamond /> {attempt.attempt[0]} ({roll.dice[0]}
                 ) <Diamond /> {attempt.attempt[1]} ({roll.dice[1]}) <Diamond />{" "}
-                {format(attempt.timestamp.toDate(), "dd/mm/yyyy hh:mm:ss")}
+                {format(attempt.timestamp.toDate(), "dd/MM/yyyy hh:mm:ss")}
               </Typography>
             );
           })}


### PR DESCRIPTION
Previously, the month format was using `mm`. `mm` is for 2-digit
minutes. This was causing the date to render erroneous things like
`26/29/2024 10:29:53`, which is not a valid date.

We change the month format to use `MM`, which should give the 2-digit
month as was originally intended.

Fixes: https://github.com/fultimator/fultimator/issues/81
